### PR TITLE
Add BNB currency to stolen token lists

### DIFF
--- a/honeypot_data.py
+++ b/honeypot_data.py
@@ -17,6 +17,7 @@ WORDS = {
         "NFTs",
         "doge",
         "SHIB",
+        "BNB",
     ],
     "VERB": ["hacked", "stole", "took"],
     "CREDS": [


### PR DESCRIPTION
Adding BNB token to the stolen lists, I tried quickly but did not get any fish, but the Binance chain is a place where a lot of rug pull & scam happens so it would make sense that quite a few bots are also on the lookout for desperate users.